### PR TITLE
Release v3.5.10

### DIFF
--- a/nft.sh
+++ b/nft.sh
@@ -30,6 +30,11 @@ info()    { printf '\033[32m[信息]\033[0m %s\n' "$1"; }
 warn()    { printf '\033[33m[警告]\033[0m %s\n' "$1"; }
 err()     { printf '\033[31m[错误]\033[0m %s\n' "$1"; }
 
+pause_menu() {
+    echo ""
+    read -rp "按回车返回主菜单..." _ || true
+}
+
 # ============== root 权限检查 ==============
 check_root() {
     if [[ $EUID -ne 0 ]]; then
@@ -1145,7 +1150,11 @@ main_menu() {
 
         case "$choice" in
             1) do_install ;;
-            2) do_list ;;
+            2)
+                do_list
+                # 列表是纯输出操作；等待确认，避免主菜单立即重绘造成“无反应”的错觉。
+                pause_menu
+                ;;
             3) do_add ;;
             4) do_delete ;;
             5) do_clear_all ;;

--- a/vless-server.sh
+++ b/vless-server.sh
@@ -16,7 +16,7 @@ if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 1) ))
     exit 1
 fi
 #═══════════════════════════════════════════════════════════════════════════════
-#  多协议代理一键部署脚本 v3.5.10-preview.1 [服务端]
+#  多协议代理一键部署脚本 v3.5.10 [服务端]
 #  
 #  架构升级:
 #    • Xray 核心: 处理 TCP/TLS 协议 (VLESS/VMess/Trojan/SOCKS/SS2022)
@@ -34,7 +34,7 @@ fi
 #  作者地址:https://docs.vaiox.de/
 #═══════════════════════════════════════════════════════════════════════════════
 
-readonly VERSION="3.5.10-preview.1"
+readonly VERSION="3.5.10"
 readonly AUTHOR="Zyx0rx"
 readonly REPO_URL="https://github.com/mozisen/surge"
 readonly SCRIPT_REPO="mozisen/surge"

--- a/vless-server.sh
+++ b/vless-server.sh
@@ -28290,6 +28290,10 @@ main_menu() {
         else
             _item "1" "安装协议"
             echo -e "  ${D}───────────────────────────────────────────${NC}"
+            _item "9" "CF Tunnel(Argo)"
+            _item "10" "端口转发"
+            _item "11" "BBR 网络优化"
+            echo -e "  ${D}───────────────────────────────────────────${NC}"
             local script_update_item="检查脚本更新"
             [[ -n "$script_update_ver" ]] && script_update_item="检查脚本更新 ${Y}[有更新 v${script_update_ver}]${NC}"
             _item "12" "$script_update_item"
@@ -28322,6 +28326,9 @@ main_menu() {
         else
             case $choice in
                 1) do_install_server; skip_pause=true ;;
+                9) manage_cloudflare_tunnel; skip_pause=true ;;
+                10) manage_port_forwarding_backends; skip_pause=true ;;
+                11) enable_bbr; skip_pause=true ;;
                 12) do_update ;;
                 0) exit 0 ;;
                 *) _err "无效选择"; skip_pause=true ;;

--- a/vless-server.sh
+++ b/vless-server.sh
@@ -16,7 +16,7 @@ if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 1) ))
     exit 1
 fi
 #═══════════════════════════════════════════════════════════════════════════════
-#  多协议代理一键部署脚本 v3.5.9 [服务端]
+#  多协议代理一键部署脚本 v3.5.10-preview.1 [服务端]
 #  
 #  架构升级:
 #    • Xray 核心: 处理 TCP/TLS 协议 (VLESS/VMess/Trojan/SOCKS/SS2022)
@@ -34,7 +34,7 @@ fi
 #  作者地址:https://docs.vaiox.de/
 #═══════════════════════════════════════════════════════════════════════════════
 
-readonly VERSION="3.5.9"
+readonly VERSION="3.5.10-preview.1"
 readonly AUTHOR="Zyx0rx"
 readonly REPO_URL="https://github.com/mozisen/surge"
 readonly SCRIPT_REPO="mozisen/surge"
@@ -28047,6 +28047,65 @@ manage_port_forwarding() {
     done
 }
 
+run_nftables_port_forwarding() {
+    _header
+    echo -e "  ${W}nftables 端口转发${NC}"
+    _line
+
+    local script_url="https://raw.githubusercontent.com/mozisen/surge/main/nft.sh"
+    local script_path="./nft.sh"
+    local staged=""
+    staged=$(mktemp "${TMPDIR:-/tmp}/nft-forward.XXXXXX") || {
+        _err "无法创建 nftables 脚本临时文件"
+        return 1
+    }
+
+    _info "下载 nftables 端口转发脚本..."
+    if ! curl -fL --connect-timeout 10 --max-time 120 --retry 2 \
+        "$script_url" -o "$staged"; then
+        rm -f "$staged"
+        _err "nft.sh 下载失败"
+        return 1
+    fi
+    if [[ ! -s "$staged" ]]; then
+        rm -f "$staged"
+        _err "下载的 nft.sh 为空，已拒绝执行"
+        return 1
+    fi
+    if ! _verify_github_blob "mozisen/surge" "main" "nft.sh" "$staged"; then
+        rm -f "$staged"
+        _err "nft.sh 与 GitHub 仓库内容校验不一致，已拒绝执行"
+        return 1
+    fi
+    if ! mv -f "$staged" "$script_path" || ! chmod +x "$script_path"; then
+        rm -f "$staged"
+        _err "nft.sh 保存或授权失败"
+        return 1
+    fi
+
+    _ok "nft.sh 下载并校验完成"
+    "$script_path"
+}
+
+manage_port_forwarding_backends() {
+    while true; do
+        _header
+        echo -e "  ${W}端口转发${NC}"
+        _line
+        _item "1" "Realm 转发"
+        _item "2" "nftables 转发"
+        _item "0" "返回"
+        _line
+        read -rp "  请选择: " choice
+        case "$choice" in
+            1) manage_port_forwarding ;;
+            2) run_nftables_port_forwarding; _pause ;;
+            0) return ;;
+            *) _err "无效选择" ;;
+        esac
+    done
+}
+
 #═══════════════════════════════════════════════════════════════════════════════
 # 脚本更新与主入口
 #═══════════════════════════════════════════════════════════════════════════════
@@ -28252,7 +28311,7 @@ main_menu() {
                 7) manage_protocol_services; skip_pause=true ;;
                 8) manage_routing; skip_pause=true ;;
                 9) manage_cloudflare_tunnel; skip_pause=true ;;
-                10) manage_port_forwarding; skip_pause=true ;;
+                10) manage_port_forwarding_backends; skip_pause=true ;;
                 11) enable_bbr; skip_pause=true ;;
                 12) show_logs; skip_pause=true ;;
                 13) do_update ;;

--- a/vless-server.sh
+++ b/vless-server.sh
@@ -28052,7 +28052,7 @@ run_nftables_port_forwarding() {
     echo -e "  ${W}nftables 端口转发${NC}"
     _line
 
-    local script_url="https://raw.githubusercontent.com/mozisen/surge/main/nft.sh"
+    local script_url="https://raw.githubusercontent.com/${SCRIPT_SOURCE_REPO}/${SCRIPT_SOURCE_REF}/nft.sh"
     local script_path="./nft.sh"
     local staged=""
     staged=$(mktemp "${TMPDIR:-/tmp}/nft-forward.XXXXXX") || {
@@ -28072,7 +28072,7 @@ run_nftables_port_forwarding() {
         _err "下载的 nft.sh 为空，已拒绝执行"
         return 1
     fi
-    if ! _verify_github_blob "mozisen/surge" "main" "nft.sh" "$staged"; then
+    if ! _verify_github_blob "$SCRIPT_SOURCE_REPO" "$SCRIPT_SOURCE_REF" "nft.sh" "$staged"; then
         rm -f "$staged"
         _err "nft.sh 与 GitHub 仓库内容校验不一致，已拒绝执行"
         return 1


### PR DESCRIPTION
## 修改内容

- 在主菜单 `10) 端口转发` 下增加后端选择层。
- `1) Realm 转发` 继续进入原有 Realm + iPerf3 管理，原逻辑保持不变。
- `2) nftables 转发` 下载并执行与主脚本来源分支一致的 `nft.sh`；正式版默认使用 `main`。
- 下载使用 HTTP 失败检测、空文件检测及 GitHub blob 内容校验，通过后保存为 `./nft.sh` 并添加执行权限。
- 首次进入且尚未安装协议时，也显示 `9) CF Tunnel(Argo)`、`10) 端口转发` 和 `11) BBR 网络优化`，并接入现有功能。
- 修复 nftables 选择“查看现有端口转发”后列表立即被主菜单重绘、看起来无反应的问题；列表现在等待按回车后再返回。
- nftables 子脚本下载与主脚本的来源分支保持一致，预览分支可以直接测试配套的 `nft.sh`。
- 版本更新为正式版 `v3.5.10`。

## 用户影响

用户可以从同一个端口转发入口选择 Realm 进程转发或 nftables 内核转发，不影响已有 Realm 规则和管理功能；也可以在安装首个代理协议前使用 CF Tunnel、端口转发及 BBR。

## 修复原因

`nft.sh` 的列表功能是纯输出操作，执行后主循环立即再次打印菜单，部分终端中列表没有可确认的停留状态，因此用户会感觉选择 `2` 没有响应。

## 验证

- Realm 原函数与 main 版本逐字一致。
- 二级菜单 `1 → 2 → 0` 路由模拟通过。
- nft.sh 下载、授权及执行模拟通过。
- GitHub blob 校验失败时拒绝执行测试通过。
- 未安装协议菜单的 9/10/11 入口与功能分发检查通过。
- nftables 已有规则列表及“按回车返回”交互模拟通过。
- nftables 子脚本来源分支和 GitHub blob 校验分支一致性检查通过。
- 指定 Raw 地址实际下载、内容一致性及 Bash 语法验证通过。
- 主脚本 Bash、Zsh 语法及 `git diff --check` 通过。
